### PR TITLE
Add language selection feature to the CN site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -112,9 +112,24 @@
                                 <input type="text" name="search" class="doc-search-algolia" placeholder="搜索..." />
                             </form>
                         </li>
-                        <li>
-                            <!-- Redirect to the same page on the english website -->
-                            <a href="{{ page.url }}"><i class="fa fa-fw fa-globe"></i> English</a>
+                        <li class="nav-item dropdown">
+                            <a class="dropdown-toggle" id="languages-toggle-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true">                                
+                                <i class="fa fa-fw fa-globe"></i> 中文
+                                <span class="caret"></span> 
+                            </a>
+                            <ul class="dropdown-menu" aria-labelledby="languages-toggle-dropdown">
+                                <li>
+                                    <a href="{{ page.url }}">English</a>
+                                </li>
+                                <!--
+                                <li>
+                                    <a href="/cn{{page.url}}">中文</a>
+                                </li>
+                                -->
+                                <li>
+                                    <a href="/jp{{page.url}}">日本語</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
                             <button type="button" class="navbar-right-expand-toggle visible-xs pull-right light">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -113,7 +113,7 @@
                             </form>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="dropdown-toggle" id="languages-toggle-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true">                                
+                            <a class="dropdown-toggle" id="languages-toggle-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true" style="margin-right: 25pt;">
                                 <i class="fa fa-fw fa-globe"></i> 中文
                                 <span class="caret"></span> 
                             </a>

--- a/css/scss/themes/flat-blue.scss
+++ b/css/scss/themes/flat-blue.scss
@@ -219,12 +219,31 @@ $theme-danger-color: $color-red;
         }
       }
       .dropdown-menu {
-        background-color: $color-light-grey;
+        right: auto;
+        left: 0;
+        background-color: $color-dark-blue;
+        font-size: 16px;
+        margin-left: 25px;
+        min-width: auto;
         border-color: $color-dark-blue;
         .title {
           background-color: $color-white;
           .badge {
             background-color: $color-dark-blue;
+          }
+        }
+        & > li {
+          & > a {
+            font-family: roboto condensed,sans-serif;
+            font-weight: 700;
+            height: 60px;
+            line-height: 60px;
+            padding: 0 20px;
+            color: $color-white;
+            background-color: $color-dark-blue;
+          }
+          &:hover > a { 
+            color: $color-dark-blue-1; 
           }
         }
       }

--- a/css/themes/flat-blue.css
+++ b/css/themes/flat-blue.css
@@ -84,12 +84,27 @@
     .flat-blue .navbar.navbar-inverse .navbar-nav > li.danger.open > a {
       background-color: #FA2A00; }
     .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu {
-      background-color: #F9F9F9;
+      right: auto;
+      left: 0;
+      background-color: #353d47;
+      font-size: 16px;
+      margin-left: 25px;
+      min-width: auto;
       border-color: #353d47; }
       .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu .title {
         background-color: #FFF; }
         .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu .title .badge {
           background-color: #353d47; }
+      .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu > li > a {
+        font-family: roboto condensed,sans-serif;
+        font-weight: 700;
+        height: 60px;
+        line-height: 60px;
+        padding: 0 20px;
+        color: #FFF;
+        background-color: #353d47; }
+      .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu > li:hover > a {
+        color: #3E8ACC; }
     .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu.danger {
       border-color: #FA2A00; }
       .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu.danger .title {


### PR DESCRIPTION
Fixes https://github.com/jhipster/generator-jhipster/issues/21897

I propose to add a language selector to the Chinese site for consistency, similar to PR https://github.com/jhipster/jhipster.github.io/pull/1279.

The envisioned layout for the Chinese site is as follows:

<img width="327" alt="language-selector-cn" src="https://github.com/jhipster/cn/assets/3602892/23ebaf19-6b63-43bb-b9b9-8dc66feba73f">

